### PR TITLE
Wasm

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -172,8 +172,8 @@ int main(int argc, char *argv[])
                     false;
 #endif
 #ifdef Q_OS_HTML5
-    int newWidth, newHeight;
-    emscripten_get_canvas_element_size("#canvas", &newWidth, &newHeight);
+    double newWidth, newHeight;
+    emscripten_get_element_css_size("#canvas", &newWidth, &newHeight);
 
     int appWidth = newWidth;
     int appHeight = newHeight;

--- a/mqttdataproviderpool.cpp
+++ b/mqttdataproviderpool.cpp
@@ -130,7 +130,7 @@ void MqttDataProviderPool::startScanning()
     m_client->setPassword(QByteArray(MQTT_PASSWORD));
 
     connect(m_client, &QMqttClient::connected, [this]() {
-        QSharedPointer<QMqttSubscription> sub = m_client->subscribe(QLatin1String("sensors/active"));
+        QSharedPointer<QMqttSubscription> sub(m_client->subscribe(QLatin1String("sensors/active")));
         connect(sub.data(), &QMqttSubscription::messageReceived, this, &MqttDataProviderPool::deviceUpdate);
     });
     connect(m_client, &QMqttClient::disconnected, [this]() {


### PR DESCRIPTION
Two separate fixes:

- Compile fix for QSharedPointer in mqttdataproviderpool.cpp
- Fix startup geometry by using correct emscripten API call.

(Could we possibly remove the size setting in main.cpp altogether? At least for fullscreen mode)